### PR TITLE
Add test module-info and record; update type bound for JDK 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/.classpath
+/.project
+/.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -25,22 +25,37 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    
+
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <jdk.min.version>1.8</jdk.min.version>
+        <maven.compiler.release>16</maven.compiler.release>
+        <version.jar.plugin>3.2.0</version.jar.plugin>
     </properties>
 
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>11</version>
+        <version>38</version>
     </parent>
+
     <groupId>org.jboss.jandex</groupId>
     <artifactId>typeannotation-test</artifactId>
-    <version>1.6</version>
+    <version>1.7-SNAPSHOT</version>
     <name>Type Annotation Examples For Testing</name>
 
-    <build/>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                   <archive>
+                        <manifest>
+                            <!-- Adds ModuleMainClass attribute to module-info. -->
+                            <mainClass>test.exec.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,20 @@
+import test.ModuleAnnotation;
+
+@Deprecated
+@ModuleAnnotation("typeannotationtest")
+module org.jboss.jandex.typeannotationtest {
+
+    requires java.base;
+    requires transitive java.desktop;
+
+    exports test to java.base, java.desktop;
+
+    opens test to java.base;
+    opens test.exec to java.base;
+
+    provides test.ServiceProviderExample
+        with test.ServiceProviderExample.ServiceProviderExampleImpl;
+
+    uses test.ServiceProviderExample;
+
+}

--- a/src/main/java/test/ModuleAnnotation.java
+++ b/src/main/java/test/ModuleAnnotation.java
@@ -1,0 +1,12 @@
+package test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.MODULE)
+public @interface ModuleAnnotation {
+    String value();
+}

--- a/src/main/java/test/RecordExample.java
+++ b/src/main/java/test/RecordExample.java
@@ -1,0 +1,52 @@
+package test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@RecordExample.RecordAnnotation("Example")
+public record RecordExample(@Nullable Integer id,
+                            @Nullable
+                                @ComponentAnnotation("nameComponent")
+                                @FieldAnnotation("nameField")
+                                @AccessorAnnotation("nameAccessor")
+                                    String name) {
+
+
+    static String staticField;
+
+    static String getStaticField() {
+        return staticField;
+    }
+
+    @RecordExample.RecordAnnotation("Empty")
+    public static record NestedEmptyRecord() {
+
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.TYPE })
+    public @interface RecordAnnotation {
+        String value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.RECORD_COMPONENT })
+    public @interface ComponentAnnotation {
+        String value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.FIELD })
+    public @interface FieldAnnotation {
+        String value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.METHOD })
+    public @interface AccessorAnnotation {
+        String value();
+    }
+
+}

--- a/src/main/java/test/ServiceProviderExample.java
+++ b/src/main/java/test/ServiceProviderExample.java
@@ -1,0 +1,14 @@
+package test;
+
+public abstract class ServiceProviderExample {
+
+    public abstract String toString();
+
+    public static class ServiceProviderExampleImpl extends ServiceProviderExample {
+        @Override
+        public String toString() {
+            return "exampleImpl";
+        }
+    }
+
+}

--- a/src/main/java/test/VExample.java
+++ b/src/main/java/test/VExample.java
@@ -73,15 +73,13 @@ public class VExample {
     @Target(value = {ElementType.TYPE_USE})
     @interface M{}
 
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target(value = {ElementType.TYPE_USE})
-    @interface U{}
+    abstract class U extends V {}
 
 
 
     class S{}
     class T{}
-    class V{}
+    abstract class V implements CharSequence {}
 
 
 
@@ -91,7 +89,7 @@ public class VExample {
             public Collection<@A ? extends Integer> foo(){return null;}
 
             class O3 {
-                class Nested<@C R extends @H SU, @D SU extends String> extends O2<R, @A S>{
+                class Nested<@C R extends @H SU, @D SU extends CharSequence> extends O2<R, @A S>{
                     @Override
                     public List<@B ? extends @G Integer> foo() { return null;}
                 }

--- a/src/main/java/test/exec/Main.java
+++ b/src/main/java/test/exec/Main.java
@@ -1,0 +1,9 @@
+package test.exec;
+
+public class Main {
+
+    public static void main(String[] args) {
+        // No op
+    }
+
+}


### PR DESCRIPTION
Hi @n1hility , I am planning to submit a PR for Jandex 3.0 to support scanning annotations on record components as well as module descriptors ([branch here](https://github.com/wildfly/jandex/compare/master...MikeEdgar:module_info)). Of course, that necessitates adding examples of them here. Since records only just became GA with JDK 16, building the examples here required the new release.

Regarding the change to `VExample`, I found that the newer JDKs are better at detecting type bounds, requiring the additional relationship between the classes used as type arguments. This also minimizes changes to existing tests in Jandex.

Please let me know if this all looks reasonable when you have a moment.